### PR TITLE
Fix typo in Request Default ContentType

### DIFF
--- a/common/src/main/scala/com/ruiandrebatista/sttp/play/PlayWSClientBackend.scala
+++ b/common/src/main/scala/com/ruiandrebatista/sttp/play/PlayWSClientBackend.scala
@@ -52,7 +52,7 @@ class PlayWSClientBackend(wsClient: WSClient, mustCloseClient: Boolean, backendO
     val (maybeBody, maybeContentType) = requestBodyToWsBodyAndContentType(request.body)
 
     val contentType = request.headers.toMap
-      .get(HeaderNames.ContentType) orElse maybeContentType getOrElse "application/octect-stream"
+      .get(HeaderNames.ContentType) orElse maybeContentType getOrElse MediaTypes.Binary
 
     // Compute our own BodyWritable, essentially bypassing
     // play BodyWritable infrastructure


### PR DESCRIPTION
`"application/octect-stream"` -> `"application/octet-stream"`

Instead of just fixing text I've switched to MediaTypes provided by sttp library...

Warning: I have submitted this directly through github UI so haven't even tried compiling, I was hoping unittests would run automatically and pick up any potential braino's